### PR TITLE
メッセージの非同期通信化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'coffee-rails', '~> 4.2'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,9 +221,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -264,7 +261,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,68 @@
+$(function(){
+  function buildHTML(message) {
+    if (message.image) {
+      var html =
+       `<div class="messages_box__message_box">
+          <div class="messages_box__message_box__info">
+            <p class="messages_box__message_box__info__username">
+              ${message.user_name}
+            </p>
+            <p class="messages_box__message_box__info__create_at">
+            ${message.created_at}
+            </p>
+          </div>
+          <div class="messages_box__message_box__message_text">
+            <p class="lower-message__content">
+              ${message.content}
+            </p>
+            <img class="lower-message__image" src=${message.image}>
+          </div>
+        </div>`
+      return html;  
+    } else {
+      var html = 
+        `<div class="messages_box__message_box">
+          <div class="messages_box__message_box__info">
+            <p class="messages_box__message_box__info__username">
+              ${message.user_name}
+            </p>
+            <p class="messages_box__message_box__info__create_at">
+            ${message.created_at}
+            </p>
+          </div>
+          <div class="messages_box__message_box__message_text">
+            <p class="lower-message__content">
+              ${message.content}
+            </p>
+          </div>
+        </div>`
+      return html  
+    };
+  }
+  $('#new_message').on('submit', function(e){
+    e.preventDefault()
+    var formData = new FormData(this);
+    var url = $(this).attr('action')
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function (data) {
+      var html = buildHTML(data);
+      $('.messages_box').append(html);
+      $('form')[0].reset();
+      $('.form__submit').prop("disabled", false);
+      $('.messages_box').animate({ scrollTop: $('.messages_box')[0].scrollHeight });
+
+    })
+    .fail(function () {
+      alert("メッセージ送信に失敗しました");
+    });
+  });
+});
+
+

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,9 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,8 @@
     %meta{content: "text/html; charset=UTF-8", "http-equiv": "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_name @message.user.name
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.content @message.content
+json.image @message.image_url


### PR DESCRIPTION
#what
メッセージ機能の非同期通信ができるようにすること
jqueryの構築
turbolinksの削除
message.jsを追加し、Ajaxの処理を入れる
メッセージコントローラのcreateアクションにHTMLorr JSONに振り分ける処理を追加。

#why
リロードをしなくてもメッセージのやりとりができるようにするため
メッセージ機能の操作性をUPするため